### PR TITLE
Fix Eclipse version

### DIFF
--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="fr.centralesupelec.edf.riseclipse.developer.eclipse" sequenceNumber="1633787579">
+<target name="fr.centralesupelec.edf.riseclipse.developer.eclipse" sequenceNumber="1638440734">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.core.commands" version="3.10.100.v20210722-1426"/>
@@ -27,7 +27,7 @@
       <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
       <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
       <unit id="org.antlr.runtime" version="3.5.2.v20200724-1452"/>
-      <repository id="orbit-2021-09" location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository/"/>
+      <repository id="orbit-2021-09" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210825222808/repository/"/>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
@@ -27,7 +27,7 @@
       <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
       <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
       <unit id="org.antlr.runtime" version="3.5.2.v20200724-1452"/>
-      <repository id="orbit-2021-09" location="https://download.eclipse.org/tools/orbit/downloads/drops/I20210923151929/repository/"/>
+      <repository id="orbit-2021-09" location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository/"/>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
@@ -22,7 +22,7 @@ location "http://download.eclipse.org/releases/2021-09" {
     org.eclipse.xtext.util
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository/" orbit-2021-09 {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210825222808/repository/" orbit-2021-09 {
     org.apache.commons.lang3
     com.google.guava
     com.google.inject

--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
@@ -22,7 +22,7 @@ location "http://download.eclipse.org/releases/2021-09" {
     org.eclipse.xtext.util
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/I20210923151929/repository/" orbit-2021-09 {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository/" orbit-2021-09 {
     org.apache.commons.lang3
     com.google.guava
     com.google.inject

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/LICENSE.txt
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/LICENSE.txt
@@ -1,0 +1,165 @@
+		   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/README.md
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/README.md
@@ -1,27 +1,61 @@
 Copyright (c) 2021 CentraleSupélec & EDF.
-All rights reserved.\
-This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v2.0
-which accompanies this distribution, and is available at
-https://www.eclipse.org/legal/epl-v20.html
+
+This program is free software: 
+
+>  you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  General Public License as published by the Free Software Foundation, either 
+  version 3 of the License, or (at your option) any later version. This program 
+  is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  PURPOSE. See the GNU General Lesser Public License for more details. You 
+  should have received a copy of the GNU General Lesser Public License along 
+  with this program. If not, see <http://www.gnu.org/licenses/lgpl-3.0.html>.
 
 This file is part of the RiseClipse tool.
+ 
+### Contributors:
+  * Computer Science Department, CentraleSupélec
+  * EDF R&D
+### Contacts:
+  * dominique.marcadet@centralesupelec.fr
+  * aurelie.dehouck-neveu@edf.fr
+### Web site:
+  * <https://riseclipse.github.io>
 
-### Contributors
+****
 
-Computer Science Department, CentraleSupélec\
-EDF R&D
-
-### Contacts
-
-dominique.marcadet@centralesupelec.fr\
-aurelie.dehouck-neveu@edf.fr
-
-### Web site
-
-https://riseclipse.github.io
+This project is used to create maven artifacts from Eclipse plugins. This is needed 
+for building fat jars which run outside Eclipse.
 
 
-### Aggregation file edition
+This project is based on work by German Vega [(see this message)](https://www.eclipse.org/forums/index.php?t=msg&th=1097672&goto=1826425&#msg_1826425).
 
-To edit the `riseclipse.aggr` file, please use the CBI/aggregator tool (https://wiki.eclipse.org/CBI/aggregator).
+The following is an extract of the `pom.xml` file present in the archive :
+>This file is part of VASCO Model Transformation - Platform Eclipse Modeling Framework 4.15 Maven repository
+
+>Please visit http://vasco.imag.fr for further information
+
+>Authors : German Vega , Yves ledru , Akram Idani 
+
+>> Laboratoire d'Informatique de Grenoble, Team VASCO
+
+> Copyright (C) 2016 - 2020 University of Grenoble Alpes
+
+>  This program is free software: 
+
+>  	you can redistribute it and/or modify it under the terms of the GNU Lesser 
+  	General Public License as published by the Free Software Foundation, either 
+  	version 3 of the License, or (at your option) any later version. This program 
+  	is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+  	without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+  	PURPOSE. See the GNU General Lesser Public License for more details. You 
+  	should have received a copy of the GNU General Lesser Public License along 
+  	with this program. If not, see <http://www.gnu.org/licenses/lgpl-3.0.html>.
+
+****
+
+The `src/main/resources/riseclipse.aggr` file should be edited with the 
+[CBI/aggregator](https://wiki.eclipse.org/CBI/aggregator) tool.
+
+Changes in this file should usually also be done in the target platform 
+(project `fr.centralesupelec.edf.riseclipse.developer.eclipse`).

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/README.md
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/README.md
@@ -20,3 +20,8 @@ aurelie.dehouck-neveu@edf.fr
 ### Web site
 
 https://riseclipse.github.io
+
+
+### Aggregation file edition
+
+To edit the `riseclipse.aggr` file, please use the CBI/aggregator tool (https://wiki.eclipse.org/CBI/aggregator).

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/README.md
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/README.md
@@ -1,0 +1,22 @@
+Copyright (c) 2021 CentraleSupélec & EDF.
+All rights reserved.\
+This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+https://www.eclipse.org/legal/epl-v20.html
+
+This file is part of the RiseClipse tool.
+
+### Contributors
+
+Computer Science Department, CentraleSupélec\
+EDF R&D
+
+### Contacts
+
+dominique.marcadet@centralesupelec.fr\
+aurelie.dehouck-neveu@edf.fr
+
+### Web site
+
+https://riseclipse.github.io

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
@@ -1,25 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
-*************************************************************************
-**  Copyright (c) 2021 CentraleSupélec & EDF.
-**  All rights reserved. This program and the accompanying materials
-**  are made available under the terms of the Eclipse Public License v2.0
-**  which accompanies this distribution, and is available at
-**  https://www.eclipse.org/legal/epl-v20.html
-** 
-**  This file is part of the RiseClipse tool
-**  
-**  Contributors:
-**      Computer Science Department, CentraleSupélec
-**      EDF R&D
-**  Contacts:
-**      dominique.marcadet@centralesupelec.fr
-**      aurelie.dehouck-neveu@edf.fr
-**  Web site:
-**      https://riseclipse.github.io
-*************************************************************************
--->
-
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse Projects for RiseClipse" packedStrategy="UNPACK" mavenResult="true" versionFormat="MavenRelease">
   <validationSets label="Eclipse needed projects for RiseClipse">
     <contributions label="Eclipse Platform 2021-09">
@@ -60,7 +39,7 @@
       </repositories>
     </contributions>
     <contributions label="From Orbit">
-      <repositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository">
+      <repositories location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210825222808/repository">
         <bundles name="com.google.guava" versionRange="27.1.0"/>
         <bundles name="com.google.inject" versionRange="3.0.0"/>
         <bundles name="javax.inject" versionRange="1.0.0"/>
@@ -70,7 +49,7 @@
       </repositories>
     </contributions>
     <validationRepositories location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
-    <validationRepositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository"/>
+    <validationRepositories location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210825222808/repository"/>
   </validationSets>
   <configurations architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
@@ -60,7 +60,7 @@
       </repositories>
     </contributions>
     <contributions label="From Orbit">
-      <repositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20210923151929/repository">
+      <repositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository">
         <bundles name="com.google.guava" versionRange="27.1.0"/>
         <bundles name="com.google.inject" versionRange="3.0.0"/>
         <bundles name="javax.inject" versionRange="1.0.0"/>
@@ -70,7 +70,7 @@
       </repositories>
     </contributions>
     <validationRepositories location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
-    <validationRepositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20210923151929/repository"/>
+    <validationRepositories location="https://download.eclipse.org/tools/orbit/downloads/drops/I20211122170238/repository"/>
   </validationSets>
   <configurations architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>


### PR DESCRIPTION
The Orbit version used in the build process was not valid (the repository was not found: [link to the repository](https://download.eclipse.org/tools/orbit/downloads/drops/I20210923151929/repository/)).

We replaced this version by a working one and we can now build the fatjar correctly.