### PR TITLE
Workflow to release and prepare next development version

### DIFF
--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -128,6 +128,7 @@ jobs:
         branch: do_release
         labels: automated pr
         title: '[action] Prepare for next development iteration after release'
+        path: ${{ github.event.repository.name }}
 
     # This step is tricky but allows to keep the version in the uploaded artifacts
     - name: Get artifact name et basedir from jarPath

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -17,10 +17,10 @@
 # **      https://riseclipse.github.io
 # *************************************************************************
 
-name: Prepare for next developement version
+name: Prepare for next development version
 
-# This CD workflow prepares the next developement for riseclipse tools
-# It creates 2 commits with release and next developement versions and then creates a PR
+# This CD workflow prepares the next development for riseclipse tools
+# It creates 2 commits with release and next development versions and then creates a PR
 # It also generates artifacts between the 2 commits to have the correct version of the generated package
 # Should be called by a trigger on master branch of RiseClipse tools repositories
 
@@ -33,6 +33,9 @@ on:
       jarPath2:
         type: string
         required: false
+      toolVersionPath:
+        type: string
+        required: true
 
 jobs:
   prepare_next_dev:
@@ -103,14 +106,14 @@ jobs:
         cd ${{ github.event.repository.name }}
         mvn package
 
-    - name: Prepare for next developement version
+    - name: Prepare next development version attributes
       run: |
         cd ${{ github.event.repository.name }}
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
-        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/"  RiseClipseValidatorSCL.java
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    - name: Commit next developpement version and push all changes
+    - name: Commit next developpement version and push all changes (including tags)
       run: |
         cd ${{ github.event.repository.name }}
         git add --all

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -144,11 +144,11 @@ jobs:
         mvn clean
 # NEED TO INCREMENT VERSION HERE
 
-    - name: Commit and push next developpement version
-      run: |
-        cd ${{ github.event.repository.name }}
-        git add --all
-        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+    # - name: Commit and push next developpement version
+    #   run: |
+    #     cd ${{ github.event.repository.name }}
+    #     git add --all
+    #     git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -1,0 +1,176 @@
+# *************************************************************************
+# **  Copyright (c) 2022 CentraleSupélec & EDF.
+# **  All rights reserved. This program and the accompanying materials
+# **  are made available under the terms of the Eclipse Public License v2.0
+# **  which accompanies this distribution, and is available at
+# **  https://www.eclipse.org/legal/epl-v20.html
+# ** 
+# **  This file is part of the RiseClipse tool
+# **  
+# **  Contributors:
+# **      Computer Science Department, CentraleSupélec
+# **      EDF R&D
+# **  Contacts:
+# **      dominique.marcadet@centralesupelec.fr
+# **      aurelie.dehouck-neveu@edf.fr
+# **  Web site:
+# **      https://riseclipse.github.io
+# *************************************************************************
+
+name: Prepare for next developement version
+
+# This CD workflow prepares the next developement for riseclipse tools
+# It creates 2 commits with release and next developement versions and then creates a PR
+# It also generates artifacts
+# Should be called by a trigger on master branch of RiseClipse tools repositories
+
+on:
+  workflow_call:
+    secrets:
+      RISECLIPSE_PGP_KEY_PRIVATE:
+        required: true
+      RISECLIPSE_PGP_KEY_PASSWORD:
+        required: true
+      RISECLIPSE_OSSRH_USERNAME:
+        required: true
+      RISECLIPSE_OSSRH_PASSWORD:
+        required: true
+    inputs:
+      jarPath1:
+        type: string
+        required: true
+      jarPath2:
+        type: string
+        required: false
+
+jobs:
+  prepare_next_dev:
+    runs-on: ubuntu-latest
+    name: Prepare for next developpement version
+
+    steps:
+    - name: Checkout ${{ github.event.repository.name }}
+      uses: actions/checkout@v3
+      with:
+        path: ${{ github.event.repository.name }}
+
+    # Adapted from
+    # https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven
+    - name: Setup Environment
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
+        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.RISECLIPSE_PGP_KEY_PRIVATE }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - name: Checkout riseclipse-developper
+      uses: actions/checkout@v3
+      with:
+        repository: riseclipse/riseclipse-developer
+        path: riseclipse-developer
+        ref: master
+
+    - name: Install P2_to_M2
+      run: |
+        cd riseclipse-developer/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2
+        mvn install
+
+    - name: Configure Git User
+      run: |
+        cd ${{ github.event.repository.name }}
+        git config user.email github-actions@github.com
+        git config user.name "GitHub Actions"
+
+    # master branch is protected: work in another branch and do a PR
+    - name: Switch branch to do Release
+      run: |
+        cd ${{ github.event.repository.name }}
+        git branch do_release
+        git switch do_release
+        git push --set-upstream origin do_release
+
+    - name: Prepare for Release version (remove snapshot)
+      if: ${{ inputs.isTool == "true" }}
+      run: |
+        cd ${{ github.event.repository.name }}
+        mvn versions:set -DremoveSnapshot=true
+
+    - name: Extract Maven project version
+      run: |
+        cd ${{ github.event.repository.name }}
+        VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
+        echo "::set-output name=project_version::$VERSION"
+      id: get_version
+
+    - name: Commit this new version and create tag
+      run: |
+        cd ${{ github.event.repository.name }}
+        git add --all
+        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git tag ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}
+
+    - name: Package application
+      run: |
+        cd ${{ github.event.repository.name }}
+        mvn package
+
+    - name: Prepare for next developement version
+      run: |
+        cd ${{ github.event.repository.name }}
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        DATE=$(date "+(%d %B %Y)")
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/"  RiseClipseValidatorSCL.java
+
+    - name: Commit next developpement version and push all changes
+      run: |
+        cd ${{ github.event.repository.name }}
+        git add --all
+        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git push
+
+    - name: Clean before creating PR and push tag
+      run: |
+        cd ${{ github.event.repository.name }}
+        mvn clean
+        git push --tags
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        base: master
+        branch: do_release
+        labels: automated pr
+        title: '[action] Prepare for next development iteration after release'
+
+    # This step is tricky but allows to keep the version in the uploaded artifacts
+    - name: Get artifact name et basedir from jarPath
+      run: |
+        jarPath1="${{ inputs.jarPath1 }}"
+        jarPath2="${{ inputs.jarPath2 }}"
+        ARTIFACT_1_NO_EXT="${jarPath1%.*}"
+        ARTIFACT_2_NO_EXT="${jarPath2%.*}"
+        ARTIFACT_1_FILENAME=$( echo $(basename "${jarPath1%.*}"))
+        ARTIFACT_2_FILENAME=$( echo $(basename "${jarPath2%.*}"))
+        echo "::set-output name=artifact_1_no_ext::$ARTIFACT_1_NO_EXT"
+        echo "::set-output name=artifact_2_no_ext::$ARTIFACT_2_NO_EXT"
+        echo "::set-output name=artifact_1_filename::$ARTIFACT_1_FILENAME"
+        echo "::set-output name=artifact_2_filename::$ARTIFACT_2_FILENAME"
+      id: artifact_name
+
+    - name: Upload artifact 1
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.artifact_name.outputs.artifact_1_filename }}-${{ steps.get_version.outputs.project_version }}.jar
+        path: ${{ github.workspace }}/${{ steps.artifact_name.outputs.artifact_1_no_ext }}-${{ steps.get_version.outputs.project_version }}.jar
+
+    - name: Upload artifact 2 if exists
+      if: "${{ inputs.jarPath2 != '' }}"
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.artifact_name.outputs.artifact_2_filename }}-${{ steps.get_version.outputs.project_version }}.jar
+        path: ${{ github.workspace }}/${{ steps.artifact_name.outputs.artifact_2_no_ext }}-${{ steps.get_version.outputs.project_version }}.jar

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -113,17 +113,13 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    - name: Commit next developpement version and push all changes (including tags)
-      run: |
-        cd ${{ github.event.repository.name }}
-        git add --all
-        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-        git push
-
-    - name: Clean before creating PR and push tag
+    - name: Clean, commit and push next developpement version and tags
       run: |
         cd ${{ github.event.repository.name }}
         mvn clean
+        git add --all
+        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git push
         git push --tags
 
     - name: Create Pull Request

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -81,7 +81,7 @@ jobs:
         git switch do_release
         git push --set-upstream origin do_release
 
-    - name: Prepare for Release version (remove snapshot and update file)
+    - name: Prepare and commit Release version (remove snapshot and update file)
       run: |
         cd ${{ github.event.repository.name }}
         mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
@@ -89,15 +89,11 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION = \"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
         echo "::set-output name=project_version::$VERSION"
-      id: get_version
-
-    - name: Commit this new version and create tag
-      run: |
-        cd ${{ github.event.repository.name }}
         git add --all
         git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
         git tag ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}
         git push --tags
+      id: get_version
 
     - name: Package application
       run: |

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -88,11 +88,6 @@ jobs:
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
-
-    - name: Extract Maven project version
-      run: |
-        cd ${{ github.event.repository.name }}
-        VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
         echo "::set-output name=project_version::$VERSION"
       id: get_version
 
@@ -145,12 +140,14 @@ jobs:
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+        echo "::set-output name=project_version::$VERSION"
+      id: next_version
         
     - name: Commit and push next developpement version
       run: |
         cd ${{ github.event.repository.name }}
         git add --all
-        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.next_version.outputs.project_version }}"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -21,20 +21,11 @@ name: Prepare for next developement version
 
 # This CD workflow prepares the next developement for riseclipse tools
 # It creates 2 commits with release and next developement versions and then creates a PR
-# It also generates artifacts
+# It also generates artifacts between the 2 commits to have the correct version of the generated package
 # Should be called by a trigger on master branch of RiseClipse tools repositories
 
 on:
   workflow_call:
-    secrets:
-      RISECLIPSE_PGP_KEY_PRIVATE:
-        required: true
-      RISECLIPSE_PGP_KEY_PASSWORD:
-        required: true
-      RISECLIPSE_OSSRH_USERNAME:
-        required: true
-      RISECLIPSE_OSSRH_PASSWORD:
-        required: true
     inputs:
       jarPath1:
         type: string
@@ -54,19 +45,12 @@ jobs:
       with:
         path: ${{ github.event.repository.name }}
 
-    # Adapted from
-    # https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven
     - name: Setup Environment
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
         java-version: '11'
         cache: 'maven'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
-        server-username: MAVEN_USERNAME
-        server-password: MAVEN_PASSWORD
-        gpg-private-key: ${{ secrets.RISECLIPSE_PGP_KEY_PRIVATE }}
-        gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Checkout riseclipse-developper
       uses: actions/checkout@v3

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -93,13 +93,12 @@ jobs:
         echo "::set-output name=project_version::$VERSION"
       id: get_version
 
-    - name: Commit and push this new version and create tag
+    - name: Commit this new version and create tag
       run: |
         cd ${{ github.event.repository.name }}
         git add --all
         git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
         git tag ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}
-        git push
         git push --tags
 
     - name: Package application
@@ -148,8 +147,6 @@ jobs:
         cd ${{ github.event.repository.name }}
         git add --all
         git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-        git push
-        sleep 120s
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -148,8 +148,8 @@ jobs:
         cd ${{ github.event.repository.name }}
         git add --all
         git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-        sleep 120s
         git push
+        sleep 120s
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -93,12 +93,14 @@ jobs:
         echo "::set-output name=project_version::$VERSION"
       id: get_version
 
-    - name: Commit this new version and create tag
+    - name: Commit and push this new version and create tag
       run: |
         cd ${{ github.event.repository.name }}
         git add --all
         git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
         git tag ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}
+        git push
+        git push --tags
 
     - name: Package application
       run: |
@@ -141,13 +143,12 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    - name: Commit and push next developpement version (including tag)
+    - name: Commit and push next developpement version
       run: |
         cd ${{ github.event.repository.name }}
         git add --all
-        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
         git push
-        git push --tags
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -81,10 +81,13 @@ jobs:
         git switch do_release
         git push --set-upstream origin do_release
 
-    - name: Prepare for Release version (remove snapshot)
+    - name: Prepare for Release version (remove snapshot and update file)
       run: |
         cd ${{ github.event.repository.name }}
         mvn versions:set -DremoveSnapshot=true
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        DATE=$(date "+(%d %B %Y)")
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
     - name: Extract Maven project version
       run: |
@@ -137,10 +140,9 @@ jobs:
     - name: Clean and prepare next development version attributes
       run: |
         cd ${{ github.event.repository.name }}
+        mvn versions:set -DremoveSnapshot=false
         mvn clean
-        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        DATE=$(date "+(%d %B %Y)")
-        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+# NEED TO INCREMENT VERSION HERE
 
     - name: Commit and push next developpement version
       run: |

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -74,11 +74,12 @@ jobs:
         git config user.name "GitHub Actions"
 
     # master branch is protected: work in another branch and do a PR
-    - name: Push version changes to do_release (or create branch)
+    - name: Create and switch to branch do_release
       run: |
         cd ${{ github.event.repository.name }}
-        git push origin --force ${{ github.ref }}:do_release
+        git branch do_release
         git switch do_release
+        git push --set-upstream origin do_release
 
     - name: Prepare for Release version (remove snapshot)
       run: |

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -143,12 +143,13 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    # - name: Commit and push next developpement version
-    #   run: |
-    #     cd ${{ github.event.repository.name }}
-    #     git add --all
-    #     git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-    #     git push
+    - name: Commit and push next developpement version
+      run: |
+        cd ${{ github.event.repository.name }}
+        git add --all
+        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        sleep 120s
+        git push
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -79,7 +79,7 @@ jobs:
         git push --set-upstream origin do_release
 
     - name: Prepare for Release version (remove snapshot)
-      if: ${{ inputs.isTool == "true" }}
+
       run: |
         cd ${{ github.event.repository.name }}
         mvn versions:set -DremoveSnapshot=true

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -48,13 +48,6 @@ jobs:
       with:
         path: ${{ github.event.repository.name }}
 
-    - name: Setup Environment
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-        cache: 'maven'
-
     - name: Checkout riseclipse-developper
       uses: actions/checkout@v3
       with:
@@ -62,6 +55,13 @@ jobs:
         path: riseclipse-developer
         ref: master
 
+    - name: Setup Environment
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
+        
     - name: Install P2_to_M2
       run: |
         cd riseclipse-developer/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2
@@ -74,15 +74,13 @@ jobs:
         git config user.name "GitHub Actions"
 
     # master branch is protected: work in another branch and do a PR
-    - name: Switch branch to do Release
+    - name: Push version changes to do_release (or create branch)
       run: |
         cd ${{ github.event.repository.name }}
-        git branch do_release
+        git push origin --force ${{ github.ref }}:do_release
         git switch do_release
-        git push --set-upstream origin do_release
 
     - name: Prepare for Release version (remove snapshot)
-
       run: |
         cd ${{ github.event.repository.name }}
         mvn versions:set -DremoveSnapshot=true

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -87,7 +87,7 @@ jobs:
         mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
-        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION = \"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
         echo "::set-output name=project_version::$VERSION"
       id: get_version
 
@@ -139,7 +139,7 @@ jobs:
         mvn build-helper:parse-version versions:set -DnextSnapshot=true -DgenerateBackupPoms=false -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
-        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION = \"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
         echo "::set-output name=project_version::$VERSION"
       id: next_version
         

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -105,35 +105,6 @@ jobs:
         cd ${{ github.event.repository.name }}
         mvn package
 
-    - name: Prepare next development version attributes
-      run: |
-        cd ${{ github.event.repository.name }}
-        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        DATE=$(date "+(%d %B %Y)")
-        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
-
-    - name: Commit and push next developpement version
-      run: |
-        cd ${{ github.event.repository.name }}
-        mvn clean
-        git add --all
-        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-        git push
-
-    - name: Clean before creating PR and push tag
-      run: |
-        mvn clean
-        git push --tags
-
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
-      with:
-        base: master
-        branch: do_release
-        labels: automated pr
-        title: '[action] Prepare for next development iteration after release'
-        path: ${{ github.event.repository.name }}
-
     # This step is tricky but allows to keep the version in the uploaded artifacts
     - name: Get artifact name et basedir from jarPath
       run: |
@@ -161,3 +132,28 @@ jobs:
       with:
         name: ${{ steps.artifact_name.outputs.artifact_2_filename }}-${{ steps.get_version.outputs.project_version }}.jar
         path: ${{ github.workspace }}/${{ steps.artifact_name.outputs.artifact_2_no_ext }}-${{ steps.get_version.outputs.project_version }}.jar
+
+    - name: Clean and prepare next development version attributes
+      run: |
+        cd ${{ github.event.repository.name }}
+        mvn clean
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        DATE=$(date "+(%d %B %Y)")
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+
+    - name: Commit and push next developpement version (including tag)
+      run: |
+        cd ${{ github.event.repository.name }}
+        git add --all
+        git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        git push
+        git push --tags
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        base: master
+        branch: do_release
+        labels: automated pr
+        title: '[action] Prepare for next development iteration after release'
+        path: ${{ github.event.repository.name }}

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -141,7 +141,7 @@ jobs:
       run: |
         cd ${{ github.event.repository.name }}
         mvn clean
-        mvn build-helper:parse-version versions:set -DnextSnapshot=true -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}
+        mvn build-helper:parse-version versions:set -DnextSnapshot=true -DgenerateBackupPoms=false -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -112,13 +112,17 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    - name: Clean, commit and push next developpement version and tags
+    - name: Commit and push next developpement version
       run: |
         cd ${{ github.event.repository.name }}
         mvn clean
         git add --all
         git commit -m "[actions] prepare release ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
         git push
+
+    - name: Clean before creating PR and push tag
+      run: |
+        mvn clean
         git push --tags
 
     - name: Create Pull Request

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -143,12 +143,12 @@ jobs:
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
 
-    - name: Commit and push next developpement version
-      run: |
-        cd ${{ github.event.repository.name }}
-        git add --all
-        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
-        git push
+    # - name: Commit and push next developpement version
+    #   run: |
+    #     cd ${{ github.event.repository.name }}
+    #     git add --all
+    #     git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+    #     git push
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
+++ b/.github/workflows/Shared-Prepare-Next-Dev-Tools.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Prepare for Release version (remove snapshot and update file)
       run: |
         cd ${{ github.event.repository.name }}
-        mvn versions:set -DremoveSnapshot=true
+        mvn versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
         VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         DATE=$(date "+(%d %B %Y)")
         sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
@@ -137,18 +137,20 @@ jobs:
         name: ${{ steps.artifact_name.outputs.artifact_2_filename }}-${{ steps.get_version.outputs.project_version }}.jar
         path: ${{ github.workspace }}/${{ steps.artifact_name.outputs.artifact_2_no_ext }}-${{ steps.get_version.outputs.project_version }}.jar
 
-    - name: Clean and prepare next development version attributes
+    - name: Clean and increment next development version attributes
       run: |
         cd ${{ github.event.repository.name }}
-        mvn versions:set -DremoveSnapshot=false
         mvn clean
-# NEED TO INCREMENT VERSION HERE
-
-    # - name: Commit and push next developpement version
-    #   run: |
-    #     cd ${{ github.event.repository.name }}
-    #     git add --all
-    #     git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
+        mvn build-helper:parse-version versions:set -DnextSnapshot=true -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        DATE=$(date "+(%d %B %Y)")
+        sed -i -r "s/String TOOL_VERSION = .*$/String TOOL_VERSION=\"$VERSION $DATE\";/" ${{ inputs.toolVersionPath }}
+        
+    - name: Commit and push next developpement version
+      run: |
+        cd ${{ github.event.repository.name }}
+        git add --all
+        git commit -m "[actions] prepare next development version ${{ github.event.repository.name }}-${{ steps.get_version.outputs.project_version }}"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
This workflow aims to push a new commit release, and then prepare the next development version just like the workflow to Release on OSSRH/Maven Central for components.

This is done with the following steps:
- Create and switch to do_release branch
- Delete the snapshot from the current commit and update version in RiseClipseValidatorSCL.java*
- Commit this new version which becomes the current available release
- Create tag for this commit and push it.
- Package application and make artifacts available for download for next workflows (from Action only, not GitHub Packages yet).
- Clean project
- _Increment current version tag to the next version_
- Commit next version
- Create PR (which also pushes commits apparently)

**The last issue I have to resolve is how to increment the next version ?**
On RiseClipse components, `mvn release plugin` does it automatically but what about components ?

The workflow might be completely refactor if I miss understood something. This is just a first attempt which fully works, except for the phase to update to the next development version.

See this PR created by the workflow as an example: https://github.com/riseclipse/riseclipse-validator-scl2003/pull/26
See this PR to add workflow trigger on RiseClipse Validator SCL: https://github.com/riseclipse/riseclipse-validator-scl2003/pull/27

Next work once increment issue is fixed:
- Update references 
- Merge this PR, and PR of SCL Validator
- Proceed to create workflow to create a Pre-Release on GH.

*RiseClipseValidator.java: the file where to change the version is configurable from the inputs, thus it's not dependant on any tool.