### PR TITLE
Workflow to release tool on DockerHub

### DIFF
--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -68,8 +68,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v1.14.1
       with:
-        username: ${{ secrets.RISECLIPSE_DOCKER_USERNAME }}
-        password: ${{ secrets.RISECLIPSE_DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2.10.0

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -24,6 +24,10 @@ name: Release on DockerHub
 # Secrets are not passed when calling reusable workflows, so you must pass them from caller
 on: 
   workflow_call:
+    inputs:
+      release_version:
+        type: string
+        required: true
     secrets:
       DOCKER_USER:
         required: true
@@ -60,11 +64,7 @@ jobs:
     - name: Rename folder to avoid errors
       run: |
         cd ${{ github.workspace }}/${{ github.event.repository.name }}/artifacts
-        ls
-        cd RiseClipseValidatorSCL-*.jar
-        ls
         rename 's/.jar//' *.jar
-        ls
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v1.14.1
@@ -77,4 +77,4 @@ jobs:
       with:
         context: ${{ github.workspace }}/${{ github.event.repository.name }}
         push: true
-        tags: riseclipse/${{ inputs.DOCKER_REPOSITORY }}:${{ steps.get_version.outputs.project_version }},riseclipse/${{ inputs.DOCKER_REPOSITORY }}:latest
+        tags: riseclipse/${{ inputs.DOCKER_REPOSITORY }}:${{ inputs.release_version }},riseclipse/${{ inputs.DOCKER_REPOSITORY }}:latest

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -56,13 +56,13 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
-        workflow: Prepare-Next-Dev.yml
+        workflow: Pre-Release-and-Prepare-Next-Dev.yml
         workflow_conclusion: success
-        path: ${{ github.workspace }}/artifacts
+        path: ${{ github.workspace }}/${{ github.event.repository.name }}/artifacts
 
     - name: Rename folder to avoid errors
       run: |
-        cd ${{ github.workspace }}/artifacts
+        cd ${{ github.workspace }}/${{ github.event.repository.name }}/artifacts
         ls
         cd RiseClipseValidatorSCL-*.jar
         ls

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -27,13 +27,10 @@ on:
     secrets:
       DOCKER_USER:
         required: true
-        type: string
       DOCKER_PASSWORD:
         required: true
-        type: string
       DOCKER_REPOSITORY:
         required: true
-        type: string
 
 jobs:
   publish_dockerhub:

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -22,14 +22,15 @@ name: Release on DockerHub
 # This CD workflow releases a Docker version of CLI tool
 
 # Secrets are not passed when calling reusable workflows, so you must pass them from caller
-on: workflow_call
-  secrets:
-    DOCKER_USER:
-      required: true
-      type: string
-    DOCKER_PASSWORD:
-      required: true
-      type: string
+on: 
+  workflow_call:
+    secrets:
+      DOCKER_USER:
+        required: true
+        type: string
+      DOCKER_PASSWORD:
+        required: true
+        type: string
 
 jobs:
   publish_dockerhub:

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -28,12 +28,13 @@ on:
       release_version:
         type: string
         required: true
+      docker_repository:
+        type: string
+        required: true
     secrets:
       DOCKER_USER:
         required: true
       DOCKER_PASSWORD:
-        required: true
-      DOCKER_REPOSITORY:
         required: true
 
 jobs:

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -64,6 +64,7 @@ jobs:
         cd RiseClipseValidatorSCL-*.jar
         ls
         rename 's/.jar//' *.jar
+        ls
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v1.14.1

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -1,0 +1,82 @@
+# *************************************************************************
+# **  Copyright (c) 2022 CentraleSupélec & EDF.
+# **  All rights reserved. This program and the accompanying materials
+# **  are made available under the terms of the Eclipse Public License v2.0
+# **  which accompanies this distribution, and is available at
+# **  https://www.eclipse.org/legal/epl-v20.html
+# ** 
+# **  This file is part of the RiseClipse tool
+# **  
+# **  Contributors:
+# **      Computer Science Department, CentraleSupélec
+# **      EDF R&D
+# **  Contacts:
+# **      dominique.marcadet@centralesupelec.fr
+# **      aurelie.dehouck-neveu@edf.fr
+# **  Web site:
+# **      https://riseclipse.github.io
+# *************************************************************************
+
+name: Release on DockerHub
+
+# This CD workflow releases a Docker version of CLI tool
+
+# Secrets are not passed when calling reusable workflows, so you must pass them from caller
+on: workflow_call
+  secrets:
+    DOCKER_USER:
+      required: true
+      type: string
+    DOCKER_PASSWORD:
+      required: true
+      type: string
+
+jobs:
+  publish_dockerhub:
+    runs-on: ubuntu-latest
+
+    steps: 
+    # NB: Needs to contain a Dockerfile at root of repository
+    - name: Checkout ${{ github.event.repository.name }}
+      uses: actions/checkout@v2
+      with:
+        path: ${{ github.event.repository.name }}
+
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        workflow: Prepare-Next-Dev.yml
+        workflow_conclusion: success
+        path: ${{ github.workspace }}/artifacts
+
+    - name: Rename folder to avoid errors
+      run: |
+        cd ${{ github.workspace }}/artifacts
+        ls
+        cd RiseClipseValidatorSCL-*.jar
+        ls
+        rename 's/.jar//' *.jar
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1.14.1
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: alsoares59/riseclipse # USE RISECLIPSE REPOSITORY
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2.10.0
+      with:
+        context: ${{ github.workspace }}/${{ github.event.repository.name }}
+        push: true
+        tags: alsoares59/${{ github.event.repository.name }}:${{ steps.get_version.outputs.project_version }} # TO BE CHANGED TO RISECLIPSE OWN REPOSITORY
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -31,19 +31,28 @@ on:
       DOCKER_PASSWORD:
         required: true
         type: string
+      DOCKER_REPOSITORY:
+        required: true
+        type: string
 
 jobs:
   publish_dockerhub:
     runs-on: ubuntu-latest
 
     steps: 
+    - name: Setup Environment
+      run: sudo apt-get install rename
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     # NB: Needs to contain a Dockerfile at root of repository
     - name: Checkout ${{ github.event.repository.name }}
       uses: actions/checkout@v2
       with:
         path: ${{ github.event.repository.name }}
 
-    - name: Download artifact
+    - name: Download artifacts
       uses: dawidd6/action-download-artifact@v2
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
@@ -64,20 +73,10 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      with:
-        images: alsoares59/riseclipse # USE RISECLIPSE REPOSITORY
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2.10.0
       with:
         context: ${{ github.workspace }}/${{ github.event.repository.name }}
         push: true
-        tags: alsoares59/${{ github.event.repository.name }}:${{ steps.get_version.outputs.project_version }} # TO BE CHANGED TO RISECLIPSE OWN REPOSITORY
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: riseclipse/${{ inputs.DOCKER_REPOSITORY }}:${{ steps.get_version.outputs.project_version }},riseclipse/${{ inputs.DOCKER_REPOSITORY }}:latest

--- a/.github/workflows/Shared-Release-On-DockerHub.yml
+++ b/.github/workflows/Shared-Release-On-DockerHub.yml
@@ -68,8 +68,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v1.14.1
       with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RISECLIPSE_DOCKER_USERNAME }}
+        password: ${{ secrets.RISECLIPSE_DOCKER_PASSWORD }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2.10.0

--- a/.github/workflows/Shared-Validate-Release.yml
+++ b/.github/workflows/Shared-Validate-Release.yml
@@ -25,9 +25,9 @@ name: Validate release on GitHub
 on: 
   workflow_call:
     outputs:
-    release_version:
-      description: "Version of the release"
-      value: ${{ jobs.release.outputs.release_version }}
+      release_version:
+        description: "Version of the release"
+        value: ${{ jobs.release.outputs.release_version }}
 
 jobs:
   release:

--- a/.github/workflows/Shared-Validate-Release.yml
+++ b/.github/workflows/Shared-Validate-Release.yml
@@ -22,12 +22,19 @@ name: Validate release on GitHub
 # This CD workflow switch from pre-release to release on GitHub
 # It aslo uploads artifacts without the rc
 
-on: workflow_call
+on: 
+  workflow_call:
+    outputs:
+    release_version:
+      description: "Version of the release"
+      value: ${{ jobs.release.outputs.release_version }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Validate release
+    outputs:
+      release_version: ${{ steps.get_version.outputs.project_version }}
 
     steps:
     - name: Setup Environment


### PR DESCRIPTION
This workflow builds a Docker version of the tool and pushes it to the Docker registry.

It does the following step:s
- Install dependencies
- Download artifacts from `Pre-Release-and-Prepare-Next-Dev.yml`(containing CLI jar).
- Login to DockerHub registry using secrets
- Build image and push it twice: one with `release_version` tag, one with `latest` tag

It's not dependant on any tool.
Just pass in the docker repository where to push the image, and login secrets.

I also slightly modifed the `Release On GitHub` workflow to pass the release_version as an input for this workflow.

You can see an example of the successful build here: https://github.com/riseclipse/riseclipse-validator-scl2003/actions/runs/2104510281
And at the GitHub registry here: https://hub.docker.com/r/riseclipse/riseclipse-validator-scl-test/tags

See this PR for merging in SCL Validator: https://github.com/riseclipse/riseclipse-validator-scl2003/pull/57