### PR TITLE
Workflow to rollback if failure occurs during pre-release process

### DIFF
--- a/.github/workflows/Shared-Rollback-If-Failure.yml
+++ b/.github/workflows/Shared-Rollback-If-Failure.yml
@@ -1,0 +1,54 @@
+# *************************************************************************
+# **  Copyright (c) 2022 CentraleSupélec & EDF.
+# **  All rights reserved. This program and the accompanying materials
+# **  are made available under the terms of the Eclipse Public License v2.0
+# **  which accompanies this distribution, and is available at
+# **  https://www.eclipse.org/legal/epl-v20.html
+# ** 
+# **  This file is part of the RiseClipse tool
+# **  
+# **  Contributors:
+# **      Computer Science Department, CentraleSupélec
+# **      EDF R&D
+# **  Contacts:
+# **      dominique.marcadet@centralesupelec.fr
+# **      aurelie.dehouck-neveu@edf.fr
+# **  Web site:
+# **      https://riseclipse.github.io
+# *************************************************************************
+
+name: Rollback if failure
+
+# This CD workflow rollbacks the Pre-Release and Prepare next development version
+# When a PR is closed or in if the prepare-next-dev workflow fails
+# Proceeds to delete do_release branch, delete the pre-release and delete the tag
+
+on: workflow_call
+
+jobs:
+  rollback-if-failure:
+    runs-on: ubuntu-latest
+    name: Rollback if failure
+
+    steps:
+    - name: Delete branch do_release
+      uses: dawidd6/action-delete-branch@v3
+      with:
+        github_token: ${{github.token}}
+        branches: do_release
+
+    - name: Get latest pre-release
+      uses: rez0n/actions-github-release@main
+      id: release-tag
+      env:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: riseclipse/${{ github.event.repository.name }}
+        type: "prerelease"
+
+    - name: Delete pre-release and tag
+      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      with:
+        delete_release: true
+        tag_name: ${{ steps.release-tag.outputs.release }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow deletes:
- pre-release
- associated tag
- do_release branch

It can be triggered:
- manually 
- whenever a PR based on `do_release `is `closed` and `not merged`

I couldn't test the last trigger because I think this workflow must be on master for the trigger to work

We can test the last trigger when [this PR](https://github.com/riseclipse/riseclipse-validator-scl2003/pull/60) for this workflow is merged. Then just close [this PR](https://github.com/riseclipse/riseclipse-validator-scl2003/pull/59) (the one automatically generated)

See this workflow run that succeeds: https://github.com/riseclipse/riseclipse-validator-scl2003/actions/runs/2104748900