### PR TITLE
add fetch-depth: 0 to checkout

### DIFF
--- a/.github/workflows/Shared-Verify-Components.yml
+++ b/.github/workflows/Shared-Verify-Components.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: ${{ github.event.repository.name }}
+        fetch-depth: 0
 
     - name: Setup Environment
       uses: actions/setup-java@v2


### PR DESCRIPTION
This should remove a warning of Sonar about shallow clone