### PR TITLE
add input for running sonarqube

### DIFF
--- a/.github/workflows/Shared-Verify-Components.yml
+++ b/.github/workflows/Shared-Verify-Components.yml
@@ -58,7 +58,7 @@ jobs:
         mvn verify
 
     - name: Run analysis with Sonarqube
-      if: run_sonarqube
+      if: inputs.run_sonarqube
       run: |
         cd ${{ github.event.repository.name }}
         mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.organization=riseclipse \

--- a/.github/workflows/Shared-Verify-Components.yml
+++ b/.github/workflows/Shared-Verify-Components.yml
@@ -24,6 +24,11 @@ name: Verify components
 
 on:
   workflow_call:
+    inputs:
+      run_sonarqube:
+        type: boolean
+        required: false
+        default: true
     secrets:
       SONAR_TOKEN:
         required: true
@@ -53,6 +58,7 @@ jobs:
         mvn verify
 
     - name: Run analysis with Sonarqube
+      if: run_sonarqube
       run: |
         cd ${{ github.event.repository.name }}
         mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.organization=riseclipse \

--- a/.github/workflows/Shared-Verify-Components.yml
+++ b/.github/workflows/Shared-Verify-Components.yml
@@ -31,7 +31,7 @@ on:
         default: true
     secrets:
       SONAR_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
Sonarcloud detects a lot of issues in EMF-generated code. It is possible to disable sonar analysis in some folders, but there is no easy way to have the modified code in another package