### PR TITLE
Force com.google.guava version 30

### DIFF
--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.target
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="fr.centralesupelec.edf.riseclipse.developer.eclipse" sequenceNumber="1679302451">
+<target name="fr.centralesupelec.edf.riseclipse.developer.eclipse" sequenceNumber="1679495107">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.google.guava" version="31.1.0.jre"/>
+      <unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
       <unit id="com.google.inject" version="5.0.1.v20221112-0806"/>
       <unit id="javax.inject" version="1.0.0.v20220405-0441"/>
       <unit id="org.antlr.runtime" version="3.2.0.v20220404-1927"/>

--- a/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
+++ b/fr.centralesupelec.edf.riseclipse.developer.eclipse/fr.centralesupelec.edf.riseclipse.developer.eclipse.tpd
@@ -4,7 +4,8 @@ target "fr.centralesupelec.edf.riseclipse.developer.eclipse"
 environment JavaSE-11
 
 location "http://download.eclipse.org/releases/2023-03" {
-    com.google.guava
+    // package com.google.common.util.concurrent.internal is missing in com.google.guava version 31.1.0
+    com.google.guava [30.1.0,31.0.0)
     com.google.inject
     javax.inject
     org.antlr.runtime [3.2.0,3.2.1)

--- a/fr.centralesupelec.edf.riseclipse.developer.maven/pom.xml
+++ b/fr.centralesupelec.edf.riseclipse.developer.maven/pom.xml
@@ -128,7 +128,8 @@
     <!-- These version numbers are those used with an Eclipse build -->
     <!-- They should be aligned with target file (fr.centralesupelec.edf.riseclipse.developer.eclipse)
          and agregator file (fr.centralesupelec.edf.riseclipse.developer.p2_to_m2) -->
-    <com-google-guava-version>31.1.0</com-google-guava-version>
+    <!-- package com.google.common.util.concurrent.internal is missing in com.google.guava version 31.1.0 -->
+    <com-google-guava-version>30.1.0</com-google-guava-version>
     <com-google-inject-version>5.0.1</com-google-inject-version>
     <!-- com.google.inject:guice-parent depends on version 1, not 1.0.0
          which is the version referenced in Eclipse.

--- a/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
+++ b/fr.centralesupelec.edf.riseclipse.developer.p2_to_m2/src/main/resources/riseclipse.aggr
@@ -16,7 +16,7 @@
         <bundles name="org.eclipse.osgi.compatibility.state" versionRange="1.2.800"/>
         <bundles name="org.eclipse.osgi" versionRange="3.18.300"/>
         <bundles name="org.apache.log4j" versionRange="1.2.24"/>
-        <bundles name="com.google.guava" versionRange="31.1.0"/>
+        <bundles name="com.google.guava" versionRange="[30.1.0,31.0.0)"/>
         <bundles name="com.google.inject" versionRange="5.0.1"/>
         <bundles name="javax.inject" versionRange="1.0.0"/>
         <bundles name="org.antlr.runtime" versionRange="[3.2.0,3.3.0]"/>


### PR DESCRIPTION
package com.google.common.util.concurrent.internal is missing in com.google.guava version 31.1.0 Running the jar SCL validator failed with NoClassDefFoundError: com/google/common/util/concurrent/internal/InternalFutureFailureAccess