### PR TITLE
Update Shared-Rollback-If-Failure.yml

### DIFF
--- a/.github/workflows/Shared-Rollback-If-Failure.yml
+++ b/.github/workflows/Shared-Rollback-If-Failure.yml
@@ -46,7 +46,7 @@ jobs:
         type: "prerelease"
 
     - name: Delete pre-release and tag
-      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      uses: dev-drprasad/delete-tag-and-release@v0.2.1
       with:
         delete_release: true
         tag_name: ${{ steps.release-tag.outputs.release }}


### PR DESCRIPTION
action delete-tag-and-release@v0.2.0 no more available, change to v0.2.1